### PR TITLE
Code changes required to support scheduled tasks

### DIFF
--- a/lisp.c
+++ b/lisp.c
@@ -1201,16 +1201,18 @@ inline lisp _setqqbind(lisp* envp, lisp name, lisp v, int create) {
 inline PRIM _setqq(lisp* envp, lisp name, lisp v) {
     _setqqbind(envp, name, nil, 0);
 
-    // NOTE - this code has been added to fully support scheduled tasks
-    lisp bind = assoc(name, *envp);
+    // NOTE - this code has been added to fully support scheduled tasks    
+    if (eq (symbol("*at*"), name) ) {
+        lisp bind = assoc(name, *envp);
 
-    if (!bind) {
-      bind = cons(name, nil);
+        if (!bind) {
+          bind = cons(name, nil);
 
-      *envp = cons(bind, *envp);
+          *envp = cons(bind, *envp);
+        }
+
+        setcdr(bind, v);
     }
-
-    setcdr(bind, v);
 
     return v;
 }

--- a/lisp.c
+++ b/lisp.c
@@ -1200,6 +1200,18 @@ inline lisp _setqqbind(lisp* envp, lisp name, lisp v, int create) {
 
 inline PRIM _setqq(lisp* envp, lisp name, lisp v) {
     _setqqbind(envp, name, nil, 0);
+
+    // NOTE - this code has been added to fully support scheduled tasks
+    lisp bind = assoc(name, *envp);
+
+    if (!bind) {
+      bind = cons(name, nil);
+
+      *envp = cons(bind, *envp);
+    }
+
+    setcdr(bind, v);
+
     return v;
 }
 // next line only needed because C99 can't get pointer to inlined function?
@@ -2316,7 +2328,13 @@ PRIM atrun(lisp* envp) {
         }
         prev = lst;
         lst = cdr(lst);
-        //if (!lst) terpri();
+
+        if (!lst) {
+          // As the code is now, this blanks out the screen.
+          // The code could be adjusted so that this prints once only, 
+          // after a scheduled event has been executed.
+          //terpri();
+        }
     }
     return bind;
 }


### PR DESCRIPTION
This is a great project, I'm getting a lot from it.

It seems that code changes are required to complete the support for scheduled tasks. 

at() uses _setqq() to schedule a task. I've amended _setqq() to check for the symbol (`"*at*"`). It adds that symbol to the environment if necessary, and adds the associated definition to that symbol.

This change seems better than creating a new revised function for the use of at() only.

Finally, I commented out a terpri() from atrun(). Otherwise this executes every time the interpreter checks for a scheduled task being due and blanks out the screen.

I'm aware that this PR can probably be refactored. I've tried to make changes that fit in with the existing code style.

I've tested for multiple one-time scheduled tasks, and for concurrent repeating tasks. 
