### PR TITLE
Spi code

### DIFF
--- a/MAX7219_font.h
+++ b/MAX7219_font.h
@@ -1,0 +1,123 @@
+// From https://github.com/nickgammon/MAX7219/MAX7219_font.h
+// MAX7219 class
+// Author: Nick Gammon
+// Date:   17 March 2015
+//
+// PERMISSION TO DISTRIBUTE
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+
+
+
+// NOTE blanks ensure line count matches calculated index in code
+
+
+
+
+
+
+
+
+// bit patterns for the letters / digits
+static const unsigned char  HYPHEN = 0b0000001;
+
+unsigned char MAX7219_font [91] = {
+   0b0000000, // ' '
+   0b0000001, // '!'
+   0b0000001, // '"'
+   0b0000001, // '#'
+   0b0000001, // '$'
+   0b0000001, // '%'
+   0b0000001, // '&'
+   0b0000001, // '''
+   0b1001110,       // '('   - same as [
+   0b1111000,       // ')'   - same as ]
+   0b0000001, // '*'
+   0b0000001, // '+'
+   0b0000001, // ','
+   0b0000001, // '-' - LOL *is* a hyphen
+   0b0000000,       // '.'  (done by turning DP on)
+   0b0000001, // '/'
+   0b1111110,       // '0'
+   0b0110000,       // '1'
+   0b1101101,       // '2'
+   0b1111001,       // '3'
+   0b0110011,       // '4'
+   0b1011011,       // '5'
+   0b1011111,       // '6'
+   0b1110000,       // '7'
+   0b1111111,       // '8'
+   0b1111011,       // '9'
+   0b0000001, // ':'
+   0b0000001, // ';'
+   0b0000001, // '<'
+   0b0000001, // '='
+   0b0000001, // '>'
+   0b0000001, // '?'
+   0b0000001, // '@'
+   0b1110111,       // 'A'
+   0b0011111,       // 'B'
+   0b1001110,       // 'C'  
+   0b0111101,       // 'D'
+   0b1001111,       // 'E'
+   0b1000111,       // 'F'
+   0b1011110,       // 'G'
+   0b0110111,       // 'H'
+   0b0110000,       // 'I' - same as 1
+   0b0111100,       // 'J'  
+   0b0000001, // 'K'
+   0b0001110,       // 'L'
+   0b0000001, // 'M'
+   0b0010101,       // 'N'
+   0b1111110,       // 'O' - same as 0
+   0b1100111,       // 'P'
+   0b0000001, // 'Q'
+   0b0000101,       // 'R'
+   0b1011011,       // 'S'
+   0b0000111,       // 'T'
+   0b0111110,       // 'U'
+   0b0000001, // 'V'
+   0b0000001, // 'W'
+   0b0000001, // 'X'
+   0b0100111,       // 'Y'
+   0b0000001, // 'Z'
+   0b1001110,       // '['  - same as C  
+   0b0000001, // backslash
+   0b1111000,       // ']' 
+   0b0000001, // '^'
+   0b0001000,       // '_'
+   0b0000001, // '`'
+   0b1111101,       // 'a'
+   0b0011111,       // 'b'
+   0b0001101,       // 'c'
+   0b0111101,       // 'd'
+   0b1001111,       // 'e'
+   0b1000111,       // 'f'
+   0b1011110,       // 'g'
+   0b0010111,       // 'h'
+   0b0010000,       // 'i' 
+   0b0111100,       // 'j'
+   0b0000001, // 'k'
+   0b0001110,       // 'l'
+   0b0000001, // 'm'
+   0b0010101,       // 'n'
+   0b1111110,       // 'o' - same as 0
+   0b1100111,       // 'p'
+   0b1110011, 		// 'q'
+   0b0000101,       // 'r'
+   0b1011011,       // 's'
+   0b0001111,       // 't'
+   0b0011100,       // 'u'
+   0b0000001, // 'v'
+   0b0000001, // 'w'
+   0b0000001, // 'x'
+   0b0100111,       // 'y'
+   0b0000001, // 'z'
+};  //  end of MAX7219_font

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 # Simple makefile for eps-lisp
-PROGRAM=*.c
+PROGRAM=esp-lisp
 include ../esp-open-rtos/common.mk
 


### PR DESCRIPTION
**This PR relates mainly to SPI functionality created to support the 8 character, 7-segment MAX7219 display. Other changes and additions are mostly in support of this functionality. It works very well for my own projects (some examples are included) and may have some wider benefit for the esp-lisp project generally.**
### MAX7219_font.h - added

There are a few projects on the web that define letters for the 8 character, 7-segment MAX7219 display. It wouldn’t be so hard to create this data from scratch, but this file makes for a good starting point. I’ve made a few changes to it but left the original developer’s copyright details in.
### Makefile – changed

The underlying esp-open-rtos project now creates a single binary (rather than two). The linking has changed, so it’s easier to go along with this for now. The firmware binary takes its name from the **PROGRAM** defined here.
### Lisp.c – changed
#### Minor items – new prims, delay, random, random_basic

**delay** - exposes vTaskDelay() (used by the spi code) to the lisp environment. It’s not an especially elegant approach, but this primitive comes in handy for my changing lights program.

**random, random_basic** – created these but not used now. Left in, as a straightforward way to build them from the lisp environment isn’t obvious.
#### Main items – new primitives, led_data, led_show

**led_data** – this supports storing a variable length list in spiData[], at a specified offset.

NOTE the MAX7219 display has two modes – in decode mode (default, value == 1), 1 displays the digit 1 etc. Otherwise a value is treated as a binary number, where each bit represents one of the seven led segments.

This primitive supports hex numbers in non-decode mode, by adjusting the value to point to the numbers/letters in the font file.

See the auto-loaded numbers defines for examples of this in use.

**led_show** – this exposes spi_led()
#### Main items – spi_led() and the functions it calls

**spi_led()** interacts with the MAX7219 display in two ways, depending on the init parameter.  If init > 0, the display is initialised is a variety of necessary ways. See the auto-loaded numbers defines for examples of this in use. The lights auto-loaded defines show a sensible order for init methods, although sometimes it seems to need a few resets for the display to start up, after which point it operates without problems. That may be related to a power supply issue rather than the software.

If init == 0, the data in spiData[] is sent to the display via SPI. The value sent is adjusted by sendChar() if decodeMode == 0.

The SPI works with data in 16-bit chunks. One set of 8 bits inform the display which character to change, and the other 8 bits determine the led segments to switch on.

The clock, cs and data pins are set high and low according to the MAX7219 display documentation, which seems to be the standard SPI pattern.
#### Main item – auto-load of defines in readeval()

pDefines is set to point to an array of strings, currently either pLightsDefines and pNumbersDefines. These are left in as examples, and pNumbersDefines documents the use of the MAX7219 display.

The flag libLoaded is initially set to zero, which causes readeval () to execute one define from the array of strings at a time, until the currentDefine counter matches defineCount. A small delay is placed between the execution of each define.

For my projects, this is a useful alternative to manual typing. It’s very handy during development, as even if defines can be stored in the flash ram, this is usually completely overwritten.
